### PR TITLE
Inline mydate logic in preppage and apply Python3 compatibility fixes

### DIFF
--- a/theme1/bin/Markdown.py
+++ b/theme1/bin/Markdown.py
@@ -3,7 +3,7 @@ import argparse
 import html
 import re
 import sys
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 
 def _normalize_newlines(text: str) -> str:
@@ -21,7 +21,7 @@ def _is_hr(block: str) -> bool:
     return re.match(r"\s*(\*\s*){3,}$", block) or re.match(r"\s*(-\s*){3,}$", block)
 
 
-def _setext_heading(block: str) -> Tuple[int, str] | None:
+def _setext_heading(block: str) -> Optional[Tuple[int, str]]:
     lines = block.split("\n")
     if len(lines) == 2:
         if re.match(r"^=+\s*$", lines[1]):
@@ -31,7 +31,7 @@ def _setext_heading(block: str) -> Tuple[int, str] | None:
     return None
 
 
-def _atx_heading(block: str) -> Tuple[int, str] | None:
+def _atx_heading(block: str) -> Optional[Tuple[int, str]]:
     match = re.match(r"^(#{1,6})\s*(.*?)\s*#*\s*$", block)
     if match:
         return len(match.group(1)), match.group(2)
@@ -174,7 +174,11 @@ def main() -> None:
         sys.stdout.write(version)
         return
 
-    text = sys.stdin.read()
+    if _unknown:
+        with open(_unknown[0], "r", encoding="utf-8") as handle:
+            text = handle.read()
+    else:
+        text = sys.stdin.read()
     html_output = markdown(text)
     if args.html4tags:
         html_output = html_output.replace(" />", ">")

--- a/theme1/bin/pyhat.py
+++ b/theme1/bin/pyhat.py
@@ -50,16 +50,15 @@ REVISION HISTORY
  4 2004-11-10 modularized the code and implemented CGI support
 --------------------------------------------------------------------"""
 
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 import getopt
 import sys
 import os
 import time
 import string
-import cgi
-from   pyhatConstants import *
-from   pyhatPass1     import *
-from   pyhatPass2     import *
+from pyhatConstants import *
+from pyhatPass1 import *
+from pyhatPass2 import *
 
 # the defaults are for CGI processing
 optionOutputDir ="pyhat_out"
@@ -71,8 +70,9 @@ optionRemoveHeadingWord1 = False
 
 def processDocument(aDocument, argRunMode):
 
-	aDocument = runPass1OnDocument(aDocument, optionQuiet, optionVerbose)		
-	if optionVerbose: print "Run mode is:", argRunMode	
+	aDocument = runPass1OnDocument(aDocument, optionQuiet, optionVerbose)
+	if optionVerbose:
+		print("Run mode is:", argRunMode)
 	
 	if argRunMode == RUNMODE_REMOVE:
 		# Our job is merely to remove the old tags.
@@ -85,7 +85,8 @@ def processDocument(aDocument, argRunMode):
 		# table of contents.  So we run the document that we have
 		# created through a second parser.  This parser re-creates
 		# the TableOfContents and its associated links.
-		if optionVerbose: print PASS2_MESSAGE
+		if optionVerbose:
+			print(PASS2_MESSAGE)
 		return runPass2OnDocument(aDocument, 
 			optionQuiet, 
 			optionVerbose, 
@@ -104,8 +105,8 @@ def main():
 	try:
 		# options that require an argument are followed by a colon
 		cmdlineOptions, args= getopt.getopt(sys.argv[1:],'d:h:vqwx')
-	except getopt.GetoptError, e:
-		raise "Error in a command-line option:\n\t" + str(e)
+	except getopt.GetoptError as e:
+		raise Exception("Error in a command-line option:\n\t" + str(e))
 
 	optionH = False	
 	for (optName,optValue) in cmdlineOptions:
@@ -120,12 +121,16 @@ def main():
 						+"\nValue must be an integer in the range of 2..6"
 						)
 					errorEnd()
-			except ValueError, e:
-					print ("Invalid argument value for option "
-						+ optName + ". It is: '" + optValue + "'"
-						+"\nValue must be an integer in the range of 2..6"
-						)
-					errorEnd()
+			except ValueError:
+				print(
+					"Invalid argument value for option "
+					+ optName
+					+ ". It is: '"
+					+ optValue
+					+ "'"
+					+ "\nValue must be an integer in the range of 2..6"
+				)
+				errorEnd()
 					
 		elif optName == '-d': optionOutputDir = optValue
 		elif optName == '-x': optionRunMode = RUNMODE_REMOVE
@@ -136,16 +141,22 @@ def main():
 			errorHandler('Option %s not recognized' % optName)
 
 	if optionRunMode == RUNMODE_REMOVE and optionRemoveHeadingWord1:
-		raise "\nOption -x (remove ToC markup) and option -w (remove first word of headings)"\
+		raise Exception(
+			"\nOption -x (remove ToC markup) and option -w (remove first word of headings)"
 			"\ncannot both be specified."
+		)
 
 	if optionRunMode == RUNMODE_REMOVE and optionH:
-		raise "\nOption -x (remove ToC markup) and option -h (deepest heading level)"\
+		raise Exception(
+			"\nOption -x (remove ToC markup) and option -h (deepest heading level)"
 			"\ncannot both be specified."
+		)
 						
 	if optionQuiet and optionVerbose:
-		raise "\nOption -q (quiet) and option -v (verbose)"\
-			"\ncannot both be specified."			
+		raise Exception(
+			"\nOption -q (quiet) and option -v (verbose)"
+			"\ncannot both be specified."
+		)
 	
 	if d_exists(optionOutputDir): pass
 	else: 
@@ -153,16 +164,16 @@ def main():
 
 	if d_exists(optionOutputDir): pass
 	else: 
-		raise "I couldn't find or create output directory: " + optionOutputDir
+		raise Exception("I couldn't find or create output directory: " + optionOutputDir)
 			
 	if len(args) == 0:
-		print __doc__
+		print(__doc__)
 		sys.exit()
 		
 	
 	if optionVerbose:
-		print "\n\nStarting pyhat"
-		print "Command-line options are:"
+		print("\n\nStarting pyhat")
+		print("Command-line options are:")
 		for (optName,optValue) in cmdlineOptions:
 			virtualPrint( "\t" + optName + ": " + optValue)
 	
@@ -174,17 +185,20 @@ def main():
 		outFilename  = os.path.normpath("%s/%s" % (optionOutputDir , tail))
 	
 		if optionQuiet: pass
-		elif optionVerbose: print PASS1_MESSAGE
+		elif optionVerbose:
+			print(PASS1_MESSAGE)
 		else:
-			print "    (%s) infile='%s'  outfile='%s'" \
+			print(
+				"    (%s) infile='%s'  outfile='%s'"
 				% (str(fcount), inFilename, outFilename)
+			)
 		
 		aDocument = getDocumentText(inFilename)
 		aDocument = processDocument(aDocument, optionRunMode)
 		writeOutputDocument(aDocument, outFilename)
 	
 		if optionVerbose:
-			print "Ending pyhat: output file is", outFilename
+			print("Ending pyhat: output file is", outFilename)
 	
 
 if __name__ == "__main__": 

--- a/theme1/bin/pyhatConstants.py
+++ b/theme1/bin/pyhatConstants.py
@@ -1,12 +1,12 @@
 """Constants for the pyhat program """
 
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 import getopt
 import sys
 import os
 import time
 import string
-import cgi
+import html
 
 #----- some constants used in verbose display ------
 PASS1_MESSAGE = """
@@ -102,7 +102,7 @@ TABLE_OF_CONTENTS_PLACEHOLDER = """<div class="table_of_contents">
 #-----------------------------------------------------------
 def toHtmlText(argString):
 	"""Convert special characters in a string to HTML elements.	"""
-	return cgi.escape(argString)
+	return html.escape(argString)
 	
 def virtualPrint(s):
 	"""add string s to the errorOutput string for CGI.
@@ -120,9 +120,9 @@ def iso_date(sep = "-"):
 	"""Return the current date in ISO-standard format
 	"""
 	year, month, day, hour, minute, second, weekday, julianday, dst = time.localtime(time.time())
-	year_AsPaddedText  = string.zfill(year , 4)
-	month_AsPaddedText  = string.zfill(month, 2)
-	day_AsPaddedText   = string.zfill(day  , 2)
+	year_AsPaddedText = str(year).zfill(4)
+	month_AsPaddedText = str(month).zfill(2)
+	day_AsPaddedText = str(day).zfill(2)
 	return year_AsPaddedText +sep +month_AsPaddedText +sep +day_AsPaddedText
 
 
@@ -130,9 +130,9 @@ def iso_time(sep = ":"):
 	"""Return the current time in ISO-standard format
 	"""
 	year, month, day, hour, minute, second, weekday, julianday, dst = time.localtime(time.time())
-	hour_text_AsPaddedText   = string.zfill(hour  , 2)
-	minute_text_AsPaddedText  = string.zfill(minute, 2)
-	second_text_AsPaddedText  = string.zfill(second, 2)
+	hour_text_AsPaddedText = str(hour).zfill(2)
+	minute_text_AsPaddedText = str(minute).zfill(2)
+	second_text_AsPaddedText = str(second).zfill(2)
 	return  hour_text_AsPaddedText +sep +minute_text_AsPaddedText +sep +second_text_AsPaddedText
 
 

--- a/theme1/bin/pyhatPass1.py
+++ b/theme1/bin/pyhatPass1.py
@@ -3,14 +3,13 @@ REVISION HISTORY
  4 2004-11-10 renamed program to "pyhat.py"
 --------------------------------------------------------------------"""
 
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 import getopt
 import sys
 import os
 import time
 import string
-import cgi
-from   pyhatConstants import *
+from pyhatConstants import *
 
 #----------------------------------------------------------
 #
@@ -84,16 +83,16 @@ class InfileParser(HTMLParser):
 	def getConstructedDocument(self):
 		s = ""
 		if optionVerbose:
-			print ("\n"*6)+ "Components in my document:\n"
+			print(("\n" * 6) + "Components in my document:\n")
 			dividerLine = "~"*70 + "\n"
 		i = 0
 		for component in self.myDocument:
 			i += 1
 			if optionVerbose:
 				if component.myDocumentState == STATE_Toc:
-					print "\n", dividerLine + "Omitting Toc\n" + dividerLine + "\n"
+					print("\n", dividerLine + "Omitting Toc\n" + dividerLine + "\n")
 				elif component.myDocumentState == STATE_Target:
-					print "\n", dividerLine + "Omitting Target\n" + dividerLine + "\n"
+					print("\n", dividerLine + "Omitting Target\n" + dividerLine + "\n")
 				else:
 					print ("\n"
 					+ dividerLine
@@ -278,11 +277,13 @@ class InfileParser(HTMLParser):
 
 	def ShowEventString(self, argString):
 		if optionVerbose:
-			print (
+			print(
 				str(self.getpos()[0]).rjust(5)
 				+ ":"
-				+ str(self.getpos()[1]).ljust(3)
-				), self.myState, argString
+				+ str(self.getpos()[1]).ljust(3),
+				self.myState,
+				argString,
+			)
 		return
 
 
@@ -455,7 +456,7 @@ class InfileParser(HTMLParser):
 		fromLineNumber = toLineNumber - ERROR_LINES_TO_PRINT
 		fromLineNumber = max(fromLineNumber, 1)
 		someLines = self.myInputText.split("\n")
-		for i in xrange(fromLineNumber-1, toLineNumber):
+		for i in range(fromLineNumber - 1, toLineNumber):
 			result +=  "(" + str(i+1) + ") " + someLines[i]
 		# point to the exact column where the error was discovered
 		columnPosition = argErrorPosition[1]

--- a/theme1/bin/pyhatPass2.py
+++ b/theme1/bin/pyhatPass2.py
@@ -3,14 +3,13 @@ REVISION HISTORY
  4 2004-11-10 renamed program to "pyhat.py"
 --------------------------------------------------------------------"""
 
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 import getopt
 import sys
 import os
 import time
 import string
-import cgi
-from   pyhatConstants import *
+from pyhatConstants import *
 
 #-----------------------------------------------------------
 #
@@ -36,7 +35,7 @@ class WorkfileDocumentComponent:
 		if self.myDocumentState == STATE_Heading:
 			try:
 				self.myHeadingLevel = int(self.myStartTag[2])
-			except Exception, e:
+			except Exception as e:
 				errorMessage(
 					"Error when attempting to extract header level "
 					+ " from tag: '" + self.myStartTag)
@@ -48,8 +47,8 @@ class WorkfileDocumentComponent:
 		self.myText +=  argText
 
 	def replaceText(self, argText):
-		if optionVerbose: 
-			print "\tCreating new table of contents"
+		if optionVerbose:
+			print("\tCreating new table of contents")
 		self.myText = argText
 
 	def setOutlineNumber(self, argText):
@@ -67,7 +66,7 @@ class WorkfileDocumentComponent:
 				if len(aListOfWordsInHeading) > 0:
 					if optionQuiet: pass
 					else:
-						print "\tRemoving", self.myStartTag, "word1:", aListOfWordsInHeading[0]
+						print("\tRemoving", self.myStartTag, "word1:", aListOfWordsInHeading[0])
 					aListOfWordsInHeading = aListOfWordsInHeading[1:]
 
 			self.myText = " ".join(aListOfWordsInHeading)
@@ -105,8 +104,10 @@ class WorkfileDocumentComponent:
 	def getTextOfLineInTableOfContents(self):
 		# this method will be executed for STATE_Heading components only
 		if self.myDocumentState == STATE_Heading: pass # no problem
-		else:  raise ("Program logic error: component.getTextOfLineInTableOfContents() method "
-			+ "called for a document component that is not a header"
+		else:
+			raise Exception(
+				"Program logic error: component.getTextOfLineInTableOfContents() method "
+				+ "called for a document component that is not a header"
 			)
 
 		# Here's where we put the limit on the deepest header to use int
@@ -170,19 +171,26 @@ class WorkfileParser(HTMLParser):
 	def getConstructedDocument(self):
 		s = ""
 		if optionVerbose:
-			print ("\n"*6)+ "Components in my document:\n"
+			print(("\n" * 6) + "Components in my document:\n")
 		i = 0
 		for component in self.myDocument:
 			i += 1
 			if optionVerbose:
-				print ("\n"
-				+ ("~"*70) + "\n"
-				+ "   Component number "+ str(i)
-				+ "   Component type: " + component.myDocumentState + "\n"
-				+ ("~"*70) + "\n"
-				+ component.toString()
-				+ "\n"
-				+ ("~"*70) + "\n"
+				print(
+					"\n"
+					+ ("~" * 70)
+					+ "\n"
+					+ "   Component number "
+					+ str(i)
+					+ "   Component type: "
+					+ component.myDocumentState
+					+ "\n"
+					+ ("~" * 70)
+					+ "\n"
+					+ component.toString()
+					+ "\n"
+					+ ("~" * 70)
+					+ "\n"
 				)
 			s += component.toString()
 		return s
@@ -194,8 +202,8 @@ class WorkfileParser(HTMLParser):
 		"""Put in the multi-level numbers"""
 		aNumbersForLevels = [0,0,0,0,0,0,0,0]
 
-		if optionVerbose: 
-			print "\tRenumbering content items..."
+		if optionVerbose:
+			print("\tRenumbering content items...")
 		holdLevel = 0
 		for aComponent in self.myListOfHeadingTags:
 			aHeadingTagLevel = aComponent.myHeadingLevel
@@ -214,8 +222,8 @@ class WorkfileParser(HTMLParser):
 			while i <= aHeadingTagLevel:
 				aComponent.setOutlineNumber(aComponent.myOutlineNumber + "." + str(aNumbersForLevels[i]))
 				i += 1
-			if optionVerbose: 
-				print "\t\t", aComponent.myStartTag, aComponent.myOutlineNumber
+			if optionVerbose:
+				print("\t\t", aComponent.myStartTag, aComponent.myOutlineNumber)
 
 			holdLevel = aHeadingTagLevel
 
@@ -260,9 +268,9 @@ class WorkfileParser(HTMLParser):
 		theTableOfContentsText += '</table>\n<!-- %s _END_ TABLE OF CONTENTS %s -->\n' %(TILDES, TILDES)
 		theTableOfContentsText += '</div>'
 
-		if optionVerbose: 
-			print "\n\tNumber of head <h#> entries =", str(len(self.myListOfHeadingTags))
-			print INSERTING_TOC_MESSAGE
+		if optionVerbose:
+			print("\n\tNumber of head <h#> entries =", str(len(self.myListOfHeadingTags)))
+			print(INSERTING_TOC_MESSAGE)
 			
 		# now that we've generated the table of contents text, we go looking
 		# for a place to put it.
@@ -276,8 +284,8 @@ class WorkfileParser(HTMLParser):
 		# we couldn't find a place to put the table of contents
 		#-----------------------------------------------------------------
 		if optionVerbose: 
-			print "Guessing where to insert TableOfContents"
-			print INSERTING_TOC_MESSAGE
+			print("Guessing where to insert TableOfContents")
+			print(INSERTING_TOC_MESSAGE)
 			
 		# We insert a place to put the table of contents.
 		# We try put it before the third component, which presumably
@@ -436,11 +444,13 @@ class WorkfileParser(HTMLParser):
 
 	def ShowEventString(self, argString):
 		if optionVerbose:
-			print (
+			print(
 				str(self.getpos()[0]).rjust(5)
 				+ ":"
-				+ str(self.getpos()[1]).ljust(3)
-				), self.myState, argString
+				+ str(self.getpos()[1]).ljust(3),
+				self.myState,
+				argString,
+			)
 		return
 
 
@@ -581,7 +591,7 @@ class WorkfileParser(HTMLParser):
 					tagLevel = int(argTag[1])
 					if tagLevel == i:
 						return True
-				except ValueError, e:
+				except ValueError:
 					return False
 			return False
 		else:


### PR DESCRIPTION
### Motivation
- Avoid spawning a subprocess to run `mydate.py` from `preppage.py` to remove dependency on the external script and potential Python environment issues. 
- Make the theme generators robust and Python 3 compatible so `make` can run reliably in modern runtimes.

### Description
- Inlined the file-modified-date logic into `preppage.py` by replacing the `subprocess` call with `os.path.getmtime` and `datetime.fromtimestamp(...).strftime("%a %b %d %Y")`, and added `from datetime import datetime` while handling `OSError` by returning an empty string. 
- Switched meta-tag and placeholder handling in `preppage.py` to safer replacements (using `re.sub` with lambda callbacks for meta tags and `str.replace` for placeholder tokens) to avoid regex escape issues. 
- Updated `Markdown.py` to accept an optional filename argument and use `Optional` typing, and ported `pyhat` utilities (`pyhat.py`, `pyhatPass1.py`, `pyhatPass2.py`, `pyhatConstants.py`) to Python 3 by switching to `html.parser`, using `html.escape`/`str.zfill`, modern `print()` and exception syntax, and replacing `xrange` with `range`.

### Testing
- Ran `make clean` in `theme1`, which completed successfully. 
- Ran `make` in `theme1`, which executed the updated generators and produced the expected `.html` outputs without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69657f0bec90832ba1af4739af8e5455)